### PR TITLE
Fix index in for loop - Slide 34

### DIFF
--- a/index.html
+++ b/index.html
@@ -312,7 +312,7 @@
 			var els = document.querySelectorAll(".foo");
 
 			for (let i=0; i&lt;els.length; i++) {
-				els[0].setAttribute("data-foo", "bar");
+				els[i].setAttribute("data-foo", "bar");
 			}
 		</code></pre>
 	</article>


### PR DESCRIPTION
Very minor change to use `i` as the index instead of `0`.